### PR TITLE
removed location / hometown->name not always provided by facebook

### DIFF
--- a/src/OAuth2/Provider/Facebook.php
+++ b/src/OAuth2/Provider/Facebook.php
@@ -37,7 +37,6 @@ class Facebook extends Provider
 			'nickname' => $user->username,
 			'name' => $user->name,
 			'email' => $user->email,
-			'location' => $user->hometown->name,
 			'gender' => $user->gender,
 			'timezone' => $user->timezone,
 			'verified' => $user->verified,


### PR DESCRIPTION
Suggestion, make it optional, as this is privacy data that is not always returned. 
