### PR TITLE
optional image in get_user_info response

### DIFF
--- a/src/OAuth2/Provider/Google.php
+++ b/src/OAuth2/Provider/Google.php
@@ -73,7 +73,7 @@ class Google extends Provider {
 			'last_name' => $user['family_name'],
 			'email' => $user['email'],
 			'location' => null,
-			'image' => $user['picture'],
+			'image' => !empty($user['picture']) ? $user['picture'] : null,
 			'description' => null,
 			'urls' => array(),
 		);


### PR DESCRIPTION
Same here - `$user['picture']` is optional and if not provided by google - raises error
