### PR TITLE
Change in composer.json for L4.1 and above support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"keywords": ["laravel", "oauth2"],
 	"homepage": "http://github.com/madewithlove/laravel-oauth2",
 	"require": {
-		"laravel/framework": "4.x"
+		"laravel/framework": "~4"
 	},
 	"autoload": {
 		"psr-0": {


### PR DESCRIPTION
This should make `composer update` work for laravel 4.1.x work now,
