### PR TITLE
Error when trying to retrieve property 'username'

### DIFF
--- a/src/OAuth2/Provider/Facebook.php
+++ b/src/OAuth2/Provider/Facebook.php
@@ -34,7 +34,7 @@ class Facebook extends Provider
 		// Create a response from the request
 		return array(
 			'uid' => $user->id,
-			'nickname' => $user->username,
+			'nickname' => (property_exists($user, 'username')?$user->username:NULL),
 			'name' => $user->name,
 			'email' => $user->email,
 			'location' => !empty($user->hometown->name) ? $user->hometown->name : null,


### PR DESCRIPTION
I received an error 'property doesn't exist' on this line when authenticating with Facebook. Just a small change to check if the property exists first.
