### PR TITLE
Setting possible empty values to null & adding avatar_url for github aut...

### DIFF
--- a/src/OAuth2/Provider/Github.php
+++ b/src/OAuth2/Provider/Github.php
@@ -40,11 +40,12 @@ class Github extends Provider {
 		return array(
 			'uid' => $user->id,
 			'nickname' => $user->login,
-			'name' => $user->name,
-			'email' => $user->email,
+			'name' => isset($user->name) ? $user->name : null,
+			'email' => isset($user->email) ? $user->email : null,
+			'avatar_url' => isset($user->avatar_url) ? $user->avatar_url : null,
 			'urls' => array(
 				'GitHub' => 'http://github.com/'.$user->login,
-				'Blog' => $user->blog,
+				'Blog' => isset($user->blog) ? $user->blog : null,
 			),
 		);
 	}


### PR DESCRIPTION
Github users might not have set a github name or given access to email, in this case the github authentication throws an error. This pull request fixes this setting possible empty values to null.
